### PR TITLE
Added support for Django <= 1.7

### DIFF
--- a/pyhermes/apps/django/urls.py
+++ b/pyhermes/apps/django/urls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import django
 from django.conf.urls import url
 
 from pyhermes.apps.django.views import subscriber_view
@@ -11,3 +11,7 @@ urlpatterns = [
         name='hermes-event-subscriber',
     ),
 ]
+
+if django.VERSION <= (1, 7):
+    from django.conf.urls import patterns
+    urlpatterns = patterns('', *urlpatterns)


### PR DESCRIPTION
In Django <= 1.7, urlpatterns should be parsed first by `django.conf.urls.patterns` (it couldn't be just a list)