### PR TITLE
Mock hermes publisher

### DIFF
--- a/contrib/hermes_mock.py
+++ b/contrib/hermes_mock.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+"""
+Simple mock of Hermes publisher, useful for local testing of communication
+between services using Hermes events. Incoming message would be "proxied" to
+publishing url with the same topic name.
+"""
+
+import argparse
+import concurrent.futures
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.request import Request, urlopen
+
+
+SUCCESS_CODE = 201
+TIMEOUT = 10  # in seconds
+MAX_WORKERS = 2
+MESSAGE_ID_HEADER = 'Hermes-Message-Id'
+RETRY_COUNT_HEADER = 'Hermes-Retry-Count'
+
+parser = argparse.ArgumentParser(description='Hermes mock server.')
+parser.add_argument(
+    '-p', '--port', dest='port', default=8888, type=int,
+    help='Port of Hermes mock server.'
+)
+parser.add_argument('-u', '--publish-url', dest='publish_url', required=True)
+args = parser.parse_args()
+
+
+def _publish(path, data, msg_id):
+    topic = path.split('/')[-1]
+    url = args.publish_url + topic + '/'
+    request = Request(
+        url,
+        data=data,
+        headers={
+            MESSAGE_ID_HEADER: msg_id,
+            RETRY_COUNT_HEADER: 0,
+        }
+    )
+    print('Publishing {} to {} (msg_id: {})'.format(data, url, msg_id))
+    try:
+        urlopen(request, timeout=TIMEOUT)
+    except Exception as e:
+        print('Exception during publishing data: {}'.format(e))
+
+
+class HermesMockHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        print('Get request on {}'.format(self.path))
+        content_len = int(self.headers.get('Content-Length', 0))
+        data = self.rfile.read(content_len)
+        msg_id = str(uuid.uuid4())
+        self.tp.submit(_publish, self.path, data, msg_id)
+        self.send_response(SUCCESS_CODE)
+        self.send_header(MESSAGE_ID_HEADER, msg_id)
+        self.end_headers()
+        return
+
+
+def main():
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=MAX_WORKERS
+    ) as executor:
+        handler = type('HermesHandler', (HermesMockHandler,), {'tp': executor})
+        server = HTTPServer(('', args.port), handler)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            server.socket.close()
+
+if __name__ == '__main__':
+    main()

--- a/docs/hermes_mock.md
+++ b/docs/hermes_mock.md
@@ -1,0 +1,34 @@
+# Hermes mock
+
+Pyhermes provides simple mock of Hermes publisher. It could be useful for local
+testing of interaction between services through Hermes events.
+
+This mock is simple http server, which forwards every request it gets to the
+subscriber (there could be only one subsriber, for now). Messages are proxied
+with the same topic as received.
+
+## Usage
+
+### Obtaining the mock
+
+To get the mock, either go to the `contrib` directory, or download it directly
+from [github](https://github.com/allegro/pyhermes/tree/master/contrib/hermes_mock.py).
+
+### Running
+
+Type `python3 hermes_mock.py --help` for possible options:
+
+```
+$ python3 hermes_mock.py --help
+usage: hermes_mock.py [-h] [-p PORT] -u PUBLISH_URL
+
+Hermes mock server.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PORT, --port PORT  Port of Hermes mock server.
+  -u PUBLISH_URL, --publish-url PUBLISH_URL
+```
+
+You could specify port, on which Hermes mock will be listening and URL of the
+subscriber.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ pages:
   - Subscribing: subscribing.md
   - Publishing: publishing.md
   - Django integration: django.md
+  - Mock client: hermes_mock.md
 theme: readthedocs
 strict: true
 dev_addr: 0.0.0.0:8003

--- a/pyhermes/subscriber.py
+++ b/pyhermes/subscriber.py
@@ -17,7 +17,8 @@ def handle_subscription(topic, raw_data, event_id, retry_count):
         * topic: name of Hermes topic
         * raw_data: string with raw data for event
         * event_id: id of Hermes event
-        * retry_count: number of retries to deliver this event (counting from 0)
+        * retry_count: number of retries to deliver this event
+          (counting from 0)
     """
     if not HERMES_SETTINGS.ENABLED:
         logger.debug('Hermes integration is disabled')
@@ -26,11 +27,9 @@ def handle_subscription(topic, raw_data, event_id, retry_count):
     subscribers = SubscribersHandlersRegistry.get_handlers(
         HERMES_SETTINGS.SUBSCRIBERS_MAPPING.get(topic, topic)
     )
-    logger.info(
-        'Received message for topic "{}" (eventID: {}, retry count: {})'.format(
-            topic, event_id, retry_count
-        )
-    )
+    logger.info((
+        'Received message for topic "{}" (eventID: {}, retry count: {})'
+    ).format(topic, event_id, retry_count))
     logger.debug('Message data {}'.format(str(data)))
     for subscriber in subscribers:
         subscriber(data)


### PR DESCRIPTION
Add simple http server mocking hermes behaviour. It's useful for testing passing events between local services.