### PR TITLE
Retry publishing to hermes in case of failure

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,10 @@ BASE_URL = 'service://hermes'
 URL_ADAPTER = consul_adapter
 ```
 
+## `RETRY_MAX_ATTEMTPS`
+
+Specify how many times pyhermes should retry communication with Hermes. Default: 3
+
 ## `PUBLISHING_GROUP`
 Configuration of Hermes group to which you application will publish messages. Keys of this dictionary are the same as in [Hermes creating group](http://hermes-pubsub.readthedocs.org/en/latest/user/publishing/#creating-group) request body. Example:
 ```python

--- a/pyhermes/__init__.py
+++ b/pyhermes/__init__.py
@@ -1,5 +1,5 @@
 from pyhermes.decorators import publisher, subscriber
-from pyhermes.publisher import publish
+from pyhermes.publishing import publish
 
 __version__ = '0.2.1'
 

--- a/pyhermes/apps/django/management/commands/hermes_test.py
+++ b/pyhermes/apps/django/management/commands/hermes_test.py
@@ -2,7 +2,7 @@
 from django.core.management.base import BaseCommand
 
 from pyhermes.exceptions import HermesPublishException
-from pyhermes.publisher import publish
+from pyhermes.publishing import publish
 from pyhermes.settings import HERMES_SETTINGS
 
 TOPICS_ALL = 'all'

--- a/pyhermes/decorators.py
+++ b/pyhermes/decorators.py
@@ -5,7 +5,7 @@ from pyhermes.registry import (
     PublishersHandlersRegistry,
     SubscribersHandlersRegistry
 )
-from pyhermes.publisher import _strip_topic_group, publish
+from pyhermes.publishing import _strip_topic_group, publish
 
 
 class subscriber(object):

--- a/pyhermes/settings.py
+++ b/pyhermes/settings.py
@@ -28,6 +28,7 @@ DEFAULTS = {
     },
     'PUBLISHING_TOPICS': {},
     'SUBSCRIBERS_MAPPING': {},
+    'RETRY_MAX_ATTEMTPS': 3,
 }
 # TODO: publishing timeout
 

--- a/pyhermes/utils.py
+++ b/pyhermes/utils.py
@@ -56,7 +56,22 @@ class override_hermes_settings(object):
         return wrapper
 
 
+# TODO(mkurek): add delay between consecutive retries
 class retry(object):
+    """
+    Decorator providing retrying in case of error in wrapped function.
+
+    Args:
+        * max_attempts (int) - maximum number of retries
+        * retry_exceptions (iterable) - exceptions, on which retry should
+          happen
+        * logger (Logger) - instance of python Logger
+
+    Usage:
+    @retry(max_attempts=4, retryExceptions=[ValueError])
+    def send_data(url, data):
+        ...
+    """
     def __init__(self, max_attempts=1, retry_exceptions=None, logger=None):
         self.max_attempts = max_attempts
         assert self.max_attempts > 0

--- a/pyhermes/utils.py
+++ b/pyhermes/utils.py
@@ -3,7 +3,6 @@ import logging
 from functools import wraps
 
 
-
 class AttributeDict(dict):
     """
     Dict which can handle access to keys using attributes.

--- a/runtests.py
+++ b/runtests.py
@@ -21,7 +21,7 @@ try:
             "pyhermes.apps.django",
         ],
         SITE_ID=1,
-        MIDDLEWARE_CLASSES=(),
+        MIDDLEWARE_CLASSES=()
     )
 
     try:

--- a/runtests.py
+++ b/runtests.py
@@ -21,7 +21,7 @@ try:
             "pyhermes.apps.django",
         ],
         SITE_ID=1,
-        MIDDLEWARE_CLASSES=()
+        MIDDLEWARE_CLASSES=(),
     )
 
     try:

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import responses
 from ddt import ddt, data, unpack
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 from pyhermes.exceptions import HermesPublishException
-from pyhermes.publisher import publish
+from pyhermes.publishing import publish
 from pyhermes.settings import HERMES_SETTINGS
 from pyhermes.utils import override_hermes_settings
 
@@ -138,3 +142,57 @@ class PublisherTestCase(TestCase):
             str(cm.exception),
             'Error pushing event to Hermes: {}.'.format(msg)
         )
+
+    @override_hermes_settings(HERMES=TEST_HERMES_SETTINGS)
+    @responses.activate
+    def test_publish_request_error_with_retry(self):
+        data = {'test': 'data'}
+        hermes_event_id = 'hermes_ok'
+        tries = [0]
+
+        def callback(request):
+            tries[0] += 1
+            print(tries)
+            if tries[0] <= 2:
+                raise ConnectionError('connection error')
+            print('Returning normal')
+            return (201, {'Hermes-Message-Id': hermes_event_id}, "")
+
+        responses.add_callback(
+            method=responses.POST,
+            url="{}/topics/{}.{}".format(
+                HERMES_SETTINGS.BASE_URL, TEST_GROUP_NAME, TEST_TOPIC
+            ),
+            match_querystring=True,
+            content_type='application/json',
+            callback=callback,
+        )
+        response = publish('{}.{}'.format(TEST_GROUP_NAME, TEST_TOPIC), data)
+        self.assertEqual(response, hermes_event_id)
+        self.assertEqual(tries[0], 3)
+
+    @override_hermes_settings(HERMES=TEST_HERMES_SETTINGS)
+    @responses.activate
+    def test_publish_request_wrong_response_code_with_retry(self):
+        data = {'test': 'data'}
+        hermes_event_id = 'hermes_ok'
+        tries = [0]
+
+        def callback(request):
+            tries[0] += 1
+            if tries[0] <= 2:
+                return (408, {}, "")
+            return (202, {'Hermes-Message-Id': hermes_event_id}, "")
+
+        responses.add_callback(
+            method=responses.POST,
+            url="{}/topics/{}.{}".format(
+                HERMES_SETTINGS.BASE_URL, TEST_GROUP_NAME, TEST_TOPIC
+            ),
+            match_querystring=True,
+            content_type='application/json',
+            callback=callback,
+        )
+        response = publish('{}.{}'.format(TEST_GROUP_NAME, TEST_TOPIC), data)
+        self.assertEqual(response, hermes_event_id)
+        self.assertEqual(tries[0], 3)

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 import responses
 from ddt import ddt, data, unpack

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from pyhermes.utils import retry
+
+
+class PublisherDecoratorTestCase(unittest.TestCase):
+    def test_retry_without_any_exceptions(self):
+        logger_mock = mock.MagicMock()
+
+        @retry(max_attempts=3, logger=logger_mock)
+        def test_func(a):
+            return a
+
+        result = test_func('ok')
+        self.assertEqual(result, 'ok')
+        self.assertEqual(logger_mock.warning.call_count, 0)
+
+    def test_retry_with_exception_in_the_middle(self):
+        tries = [0]
+        logger_mock = mock.MagicMock()
+
+        @retry(max_attempts=3, logger=logger_mock)
+        def test_func(a):
+            tries[0] += 1
+            if tries[0] <= 2:
+                raise ValueError()
+            return a
+
+        result = test_func('ok')
+        self.assertEqual(result, 'ok')
+        self.assertEqual(logger_mock.warning.call_count, 2)
+
+    def test_retry_with_exception_after_tries(self):
+        logger_mock = mock.MagicMock()
+
+        @retry(max_attempts=3, logger=logger_mock)
+        def test_func(a):
+            raise ValueError()
+
+        with self.assertRaises(ValueError):
+            test_func('ok')
+
+        self.assertEqual(logger_mock.warning.call_count, 2)
+
+    def test_retry_with_custom_exception_no_retry_on_wrong_exception(self):
+        logger_mock = mock.MagicMock()
+
+        @retry(logger=logger_mock, retry_exceptions=(IndexError,))
+        def test_func(a):
+            raise ValueError()
+
+        with self.assertRaises(ValueError):
+            test_func('ok')
+
+        self.assertEqual(logger_mock.warning.call_count, 0)
+
+    def test_retry_with_custom_exception_retry_on_proper_exception(self):
+        logger_mock = mock.MagicMock()
+
+        @retry(logger=logger_mock, retry_exceptions=(IndexError,))
+        def test_func(a):
+            raise IndexError()
+
+        with self.assertRaises(IndexError):
+            test_func('ok')
+
+        self.assertEqual(logger_mock.warning.call_count, 0)


### PR DESCRIPTION
Set `RETRY_MAX_ATTEMTPS` in settings to specify how many times pyhermes should retry communication with Hermes (default: 3)

Minor changes:
* renamed `publisher` module to `publishing`, because of conflict with `@publisher` decorator (thus `import pyhermes; pyhermes.publisher` was misleading)