### PR TITLE
Configure custom label for django app

### DIFF
--- a/pyhermes/apps/django/__init__.py
+++ b/pyhermes/apps/django/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'pyhermes.apps.django.config.PyhermesConfig'

--- a/pyhermes/apps/django/config.py
+++ b/pyhermes/apps/django/config.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class PyhermesConfig(AppConfig):
+    name = 'pyhermes.apps.django'
+    label = 'pyhermes.django'

--- a/pyhermes/settings.py
+++ b/pyhermes/settings.py
@@ -53,6 +53,7 @@ class HermesSettings(six.with_metaclass(Singleton, object)):
             raise TypeError()  # TODO: better info
         user_settings['HERMES'].update(settings)
 
+
 HERMES_SETTINGS = HermesSettings()
 
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -22,6 +22,7 @@ def fake_http_error(request):
 def fake_timeout(request):
     raise Timeout('timeout')
 
+
 TEST_GROUP_NAME = 'pl.allegro.pyhermes'
 TEST_TOPIC = 'test-publisher-topic1'
 TEST_HERMES_SETTINGS = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py27, py34, py35}-django{18,19},
-    {py27, py33, py34}-django{17},
+    {py27,py34,py35}-django{18,19},
+    {py27,py33,py34}-django{17},
 
 
 [testenv]


### PR DESCRIPTION
The default label for a Django app is its package name. Currently
Pyhermes provides its app in the pyhermes.apps.django which makes
it hard to use this library with another one.

This patch adds a custom label for the Django app.

Closes #10