### PR TITLE
Fix topic name stripping when starting with group name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ sudo: false
 
 env:
   - TOX_ENV=py36-djangodev
-  - TOX_ENV=py34-djangodev
-  - TOX_ENV=py27-djangodev
+
+  - TOX_ENV=py36-django111
+  - TOX_ENV=py34-django111
+  - TOX_ENV=py27-django111
 
   - TOX_ENV=py36-django110
   - TOX_ENV=py34-django110
@@ -36,11 +38,18 @@ matrix:
     - python: "3.5"
       env: TOX_ENV=py35-djangodev
     - python: "3.5"
+      env: TOX_ENV=py35-django111
+    - python: "3.5"
       env: TOX_ENV=py35-django110
     - python: "3.5"
       env: TOX_ENV=py35-django19
     - python: "3.5"
       env: TOX_ENV=py35-django18
+  allow_failures:
+    # Django dev is Django 2.0 now, removing python2 compatibility - allow
+    # failuers temporary
+    - env: TOX_ENV=py35-djangodev
+    - env: TOX_ENV=py36-djangodev
 
 install:
   - pip install tox flake8

--- a/pyhermes/publishing.py
+++ b/pyhermes/publishing.py
@@ -19,7 +19,7 @@ def _strip_topic_group(topic):
     """
     group_name = HERMES_SETTINGS.PUBLISHING_GROUP['groupName']
     if topic.startswith(group_name):
-        topic = topic[len(group_name):]
+        topic = topic[len(group_name):].lstrip('.')
     return topic
 
 

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -6,7 +6,7 @@ from ddt import ddt, data, unpack
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 from pyhermes.exceptions import HermesPublishException
-from pyhermes.publishing import publish
+from pyhermes.publishing import _strip_topic_group, publish
 from pyhermes.settings import HERMES_SETTINGS
 from pyhermes.utils import override_hermes_settings
 
@@ -192,3 +192,19 @@ class PublisherTestCase(TestCase):
         response = publish('{}.{}'.format(TEST_GROUP_NAME, TEST_TOPIC), data)
         self.assertEqual(response, hermes_event_id)
         self.assertEqual(tries[0], 3)
+
+
+class TestStripTopicGroupName(TestCase):
+    @override_hermes_settings(HERMES=TEST_HERMES_SETTINGS)
+    def test_stripping_group_name_when_topic_startswith_group_name(self):
+        self.assertEqual(
+            _strip_topic_group('pl.allegro.pyhermes.my-topic'),
+            'my-topic'
+        )
+
+    @override_hermes_settings(HERMES=TEST_HERMES_SETTINGS)
+    def test_stripping_group_name_when_topic_not_startswith_group_name(self):
+        self.assertEqual(
+            _strip_topic_group('my-topic'),
+            'my-topic'
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,6 @@ deps =
     django18: Django==1.8.17
     django19: Django==1.9.12
     django110: Django==1.10.4
+    django111: Django==1.11.a1
     djangodev: git+git://github.com/django/django.git
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
There was a bug causing wrong stripping of group name from topic name, which leads to prepending topic name with additional dot (ex. pl.allegro.pyhermes -> .pyhermes), which was later concatenated with double-dot (ex. pl.allegro..pyhermes)