### PR TITLE
Fix warning on docs build.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,8 @@ pages:
   - Publishing: publishing.md
   - Django integration: django.md
   - Mock client: hermes_mock.md
-theme: readthedocs
+theme:
+    name: readthedocs
 strict: true
 dev_addr: 0.0.0.0:8003
 markdown_extensions:


### PR DESCRIPTION
Move to new style `theme` configuration in mkdocs https://www.mkdocs.org/about/release-notes/#theme-customization-1164