### PR TITLE
Remove dot from Django app label

### DIFF
--- a/pyhermes/apps/django/config.py
+++ b/pyhermes/apps/django/config.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class PyhermesConfig(AppConfig):
     name = 'pyhermes.apps.django'
-    label = 'pyhermes.django'
+    label = 'pyhermes_django'


### PR DESCRIPTION
From Django 3.2 app label cannot contain dots.
More info: https://code.djangoproject.com/ticket/32285